### PR TITLE
Initial implementation

### DIFF
--- a/.cookiecutter/includes/README/head.md
+++ b/.cookiecutter/includes/README/head.md
@@ -1,0 +1,34 @@
+Commando clones a given list of GitHub repos, runs a given command in each
+repo, and sends any resulting changes as pull requests (PRs) to each repo.
+
+### Usage
+
+For example lets send PRs to repo-1, repo-2 and repo-3 to add a copyright notice to the bottom
+of each repo's `README.md` file:
+
+```console
+$ commando --repos hypothesis/repo-1 hypothesis/repo-2 hypothesis/repo-3 \
+           --command 'echo "Copyright (c) 2022 Me" >> README.md' \
+           --branch add-copyright-notice \
+           --commit-message 'Add a copyright notice to the README' \
+           --pr-title 'Add a copyright notice to the README'
+```
+
+See `commando --help` for the full list of command line options.
+
+You can give a hard-coded list of repos like in the command above or you can
+use a command to generate the `--repos` argument. For example we can use
+[GitHub CLI](https://cli.github.com/)'s
+[`gh api`](https://cli.github.com/manual/gh_api) command to call the GitHub
+REST API's [search repositories](https://docs.github.com/en/rest/search?apiVersion=2022-11-28#search-repositories)
+API and get a list of all repos in the hypothesis organization that have the
+text `cookiecutter.json` in their README file. We can then run `make template`
+to update each repo with any changes from [our cookiecutter templates](https://github.com/hypothesis/cookiecutters):
+
+```console
+$ commando --repos $(gh api -X GET search/repositories --paginate -f 'q=cookiecutter.json in:readme org:hypothesis archived:false' -q '.items | .[] | .full_name' | xargs) \
+           --command 'make template'
+           --branch cookiecutter
+           --commit-message 'Apply updates from cookiecutter'
+           --pr-title 'Apply updates from cookiecutter'
+```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,41 @@
 
 Run commands in repos and send any resulting changes as PRs.
 
+Commando clones a given list of GitHub repos, runs a given command in each
+repo, and sends any resulting changes as pull requests (PRs) to each repo.
+
+### Usage
+
+For example lets send PRs to repo-1, repo-2 and repo-3 to add a copyright notice to the bottom
+of each repo's `README.md` file:
+
+```console
+$ commando --repos hypothesis/repo-1 hypothesis/repo-2 hypothesis/repo-3 \
+           --command 'echo "Copyright (c) 2022 Me" >> README.md' \
+           --branch add-copyright-notice \
+           --commit-message 'Add a copyright notice to the README' \
+           --pr-title 'Add a copyright notice to the README'
+```
+
+See `commando --help` for the full list of command line options.
+
+You can give a hard-coded list of repos like in the command above or you can
+use a command to generate the `--repos` argument. For example we can use
+[GitHub CLI](https://cli.github.com/)'s
+[`gh api`](https://cli.github.com/manual/gh_api) command to call the GitHub
+REST API's [search repositories](https://docs.github.com/en/rest/search?apiVersion=2022-11-28#search-repositories)
+API and get a list of all repos in the hypothesis organization that have the
+text `cookiecutter.json` in their README file. We can then run `make template`
+to update each repo with any changes from [our cookiecutter templates](https://github.com/hypothesis/cookiecutters):
+
+```console
+$ commando --repos $(gh api -X GET search/repositories --paginate -f 'q=cookiecutter.json in:readme org:hypothesis archived:false' -q '.items | .[] | .full_name' | xargs) \
+           --command 'make template'
+           --branch cookiecutter
+           --commit-message 'Apply updates from cookiecutter'
+           --pr-title 'Apply updates from cookiecutter'
+```
+
 ## Installing
 
 We recommend using [pipx](https://pypa.github.io/pipx/) to install

--- a/src/commando/cli.py
+++ b/src/commando/cli.py
@@ -1,13 +1,82 @@
 from argparse import ArgumentParser
 from importlib.metadata import version
 
+from commando.core import commando
 
-def cli(_argv=None):  # pylint:disable=inconsistent-return-statements
-    parser = ArgumentParser()
-    parser.add_argument("-v", "--version", action="store_true")
+
+def cli(_argv=None):
+    parser = ArgumentParser(
+        description="Run commands in GitHub repos and send any resulting changes as pull requests (PRs)."
+    )
+
+    parser.add_argument(
+        "-v", "--version", action="version", version=version("commando")
+    )
+    parser.add_argument(
+        "--repos",
+        required=True,
+        nargs="+",
+        help="the list of GitHub repos to operate on in <owner>/<repo-name> format, example: hypothesis/repo-1 hypothesis/repo-2 hypothesis/repo-3",
+        metavar="REPO",
+    )
+    parser.add_argument(
+        "--command",
+        required=True,
+        help="the command to run in each repo, example: 'make template'",
+    )
+    parser.add_argument(
+        "--commit-message",
+        default="Automated changes by Commando",
+        help="the git commit message to use when making commits, example: 'Apply updates from cookiecutter'",
+        metavar="TEXT",
+    )
+    parser.add_argument(
+        "--commit-message-file",
+        help="path to a file containing the commit message to use when making commits",
+        metavar="PATH",
+    )
+    parser.add_argument(
+        "--branch",
+        required=True,
+        help="the branch name to use when creating PRs, example: cookiecutter",
+    )
+    parser.add_argument(
+        "--pr-title",
+        default="Automated changes by Commando",
+        help="the title to use when creating PRs, example: 'Apply updates from cookiecutter'",
+        metavar="TEXT",
+    )
+    parser.add_argument(
+        "--pr-body",
+        default="Automated changes by [Commando](https://github.com/hypothesis/commando)",
+        help="the body text to use when creating PRs",
+        metavar="TEXT",
+    )
+    parser.add_argument(
+        "--pr-body-file",
+        help="path to a file containing the body text to use when creating PRs",
+        metavar="PATH",
+    )
 
     args = parser.parse_args(_argv)
 
-    if args.version:
-        print(version("commando"))
-        return 0
+    # --commit-message-file overrides --commit-message if both are given at once.
+    if args.commit_message_file is not None:  # pragma:no cover
+        with open(
+            args.commit_message_file, "r", encoding="utf-8"
+        ) as commit_message_file:
+            args.commit_message = commit_message_file.read()
+
+    # --pr-body-file overrides --pr-body if both are given at once.
+    if args.pr_body_file is not None:  # pragma:no cover
+        with open(args.pr_body_file, "r", encoding="utf-8") as pr_body_file:
+            args.pr_body = pr_body_file.read()
+
+    return commando(
+        args.repos,
+        args.command,
+        args.commit_message,
+        args.branch,
+        args.pr_title,
+        args.pr_body,
+    )

--- a/src/commando/core.py
+++ b/src/commando/core.py
@@ -1,2 +1,123 @@
-def hello_world():
-    return "Hello, world!"
+import subprocess
+import tempfile
+from functools import partial
+from subprocess import PIPE, STDOUT, CalledProcessError
+
+
+def _pprint(repo, message):
+    print(f"{repo}> {message}")
+
+
+def _run(cwd, results, command, **kwargs):
+    result = subprocess.run(  # pylint:disable=subprocess-run-check
+        command, cwd=cwd, stdout=PIPE, stderr=STDOUT, text=True, **kwargs
+    )
+    results.append(result)
+    result.check_returncode()
+    return result
+
+
+def _process_repo(
+    repo, command, commit_message, branch, pr_title, pr_body
+):  # pylint:disable=too-many-arguments
+
+    # Collect the results of all commands run for this repo.
+    results = []
+
+    pprint = partial(_pprint, repo)
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        run = partial(_run, tmpdirname, results)
+
+        try:
+            pprint("Cloning repo")
+            run(
+                [
+                    "gh",
+                    "repo",
+                    "clone",
+                    repo,
+                    tmpdirname,
+                    "--",
+                    # Ensure that the origin remote is named 'origin', the
+                    # default name could be overridden by the git config.
+                    "--origin",
+                    "origin",
+                    # Try to speed it up by not cloning tags since we don't need them.
+                    # Note that I don't think we can speed this up even more by
+                    # using a shallow clone: gh-pr-upsert needs the commits and
+                    # history in order to compare branches.
+                    "--no-tags",
+                ]
+            )
+
+            pprint("Creating branch")
+            run(
+                [
+                    "git",
+                    "switch",
+                    # Don't automatically set upstream configuration if there's
+                    # a remote tracking branch with the same name.
+                    "--no-guess",
+                    # Don't set upstream tracking configuration.
+                    "--no-track",
+                    # Create a new branch or reset an existing one to origin/main.
+                    "--force-create",
+                    branch,
+                    "origin/main",
+                ]
+            )
+
+            pprint("Running command")
+            pprint(command)
+            run(command, shell=True)
+
+            pprint("Committing any changes")
+            run(["git", "add", "--all"])
+            run(
+                [
+                    "git",
+                    "commit",
+                    # Don't crash if there are no changes to commit.
+                    # If an empty commit is created gh-pr-upsert will do the
+                    # right thing and not create an empty PR.
+                    "--allow-empty",
+                    "--message",
+                    commit_message,
+                ]
+            )
+
+            pprint("Sending PR")
+            try:
+                result = run(["gh-pr-upsert", "--title", pr_title, "--body", pr_body])
+            except CalledProcessError as err:  # pragma: no cover
+                if err.returncode > 1:
+                    # Exit codes >1 from gh-pr-upsert are not a problem for Commando.
+                    pprint(err.stdout.rstrip())
+                else:
+                    raise
+            else:
+                pprint(result.stdout.rstrip())
+        except CalledProcessError:  # pragma: no cover
+            # Print the outputs of all the failed repo's commands.
+            for result in results:
+                print(f"$ {result.args} (returncode was: {result.returncode})")
+                # Our run() helper pipes stderr to stdout so we only need to print stdout here.
+                print(result.stdout)
+
+            raise
+
+
+def commando(
+    repos, command, commit_message, branch, pr_title, pr_body
+):  # pylint:disable=too-many-arguments
+    failed = False
+
+    for repo in repos:
+        try:
+            _process_repo(repo, command, commit_message, branch, pr_title, pr_body)
+        except CalledProcessError:  # pragma: no cover
+            failed = True
+
+    # Exit with 1 if any of the repos failed.
+    return int(failed)

--- a/tests/unit/commando/cli_test.py
+++ b/tests/unit/commando/cli_test.py
@@ -5,8 +5,58 @@ import pytest
 from commando.cli import cli
 
 
-def test_it():
-    cli([])
+def test_defaults(commando):
+    cli(
+        [
+            "--repos",
+            "hypothesis/repo-1",
+            "hypothesis/repo-2",
+            "hypothesis/repo-3",
+            "--branch",
+            "my_branch",
+            "--command",
+            "my_command",
+        ]
+    )
+
+    commando.assert_called_once_with(
+        ["hypothesis/repo-1", "hypothesis/repo-2", "hypothesis/repo-3"],
+        "my_command",
+        "Automated changes by Commando",
+        "my_branch",
+        "Automated changes by Commando",
+        "Automated changes by [Commando](https://github.com/hypothesis/commando)",
+    )
+
+
+def test_options(commando):
+    cli(
+        [
+            "--repos",
+            "hypothesis/repo-1",
+            "hypothesis/repo-2",
+            "hypothesis/repo-3",
+            "--branch",
+            "my_branch",
+            "--command",
+            "my_command",
+            "--commit-message",
+            "my_commit_message",
+            "--pr-title",
+            "my_pr_title",
+            "--pr-body",
+            "my_pr_body",
+        ]
+    )
+
+    commando.assert_called_once_with(
+        ["hypothesis/repo-1", "hypothesis/repo-2", "hypothesis/repo-3"],
+        "my_command",
+        "my_commit_message",
+        "my_branch",
+        "my_pr_title",
+        "my_pr_body",
+    )
 
 
 def test_help():
@@ -17,7 +67,13 @@ def test_help():
 
 
 def test_version(capsys):
-    exit_code = cli(["--version"])
+    with pytest.raises(SystemExit) as exc_info:
+        cli(["--version"])
 
     assert capsys.readouterr().out.strip() == version("commando")
-    assert not exit_code
+    assert not exc_info.value.code
+
+
+@pytest.fixture(autouse=True)
+def commando(mocker):
+    return mocker.patch("commando.cli.commando", autospec=True)

--- a/tests/unit/commando/core_test.py
+++ b/tests/unit/commando/core_test.py
@@ -1,6 +1,23 @@
-from commando.core import hello_world
+from unittest.mock import sentinel
+
+import pytest
+
+from commando.core import commando
 
 
-class TestHelloWorld:
+class TestCommando:
     def test_it(self):
-        assert hello_world() == "Hello, world!"
+        exit_status = commando(
+            [sentinel.repo_1, sentinel.repo_2],
+            ["test", "command"],
+            sentinel.commit_message,
+            sentinel.branch,
+            sentinel.pr_title,
+            sentinel.pr_body,
+        )
+
+        assert not exit_status
+
+    @pytest.fixture(autouse=True)
+    def subprocess(self, mocker):
+        return mocker.patch("commando.core.subprocess", autospec=True)


### PR DESCRIPTION
## Problem

When you make a change to [our cookiecutter template](https://github.com/hypothesis/cookiecutters) you then have to run `make template` in every project that uses the cookiecutter (getting close to a couple of dozen projects) and send PRs to every project. This is a waste of developers time, it's error-prone (e.g. accidentally missing out some projects), it means that projects will tend not to be kept up-to-date with the cookiecutter (because people forget or don't have time), and it discourages making changes to the cookiecutter (if you know you're then gonna have to go and manually create a couple of dozen PRs).

## Solution

Commando is a command-line tool that implements the following recipe:

1. Clones a list of GitHub repos given in a `--repos` option
2. Runs a command in each repo, the command given in a `--command` option
3. Calls [gh-pr-upsert](https://github.com/hypothesis/gh-pr-upsert/pull/3) to send any resulting changes as a PR, for each repo. The `--commit-message` / `--commit-message-file`, `--branch`, `--pr-title`, and `--pr-body` / `--pr-body-file` options specify the details of the PR to be sent

Example:

```console
$ commando --repos hypothesis/cookiecutter-pypackage-test hypothesis/cookiecutter-pyapp-test hypothesis/cookiecutter-pyramid-app-test \
           --command 'make template'
           --branch cookiecutter
           --commit-message 'Apply updates from cookiecutter'
           --pr-title 'Apply updates from cookiecutter'
```

Instead of a hard-coded list you can generate the `--repos` argument from a command. For example this GitHub search API command finds all cookiecuttered repos in the hypothesis organization:

```console
$ gh api -X GET search/repositories --paginate -f 'q=cookiecutter.json in:readme org:hypothesis archived:false' -q '.items | .[] | .full_name'
hypothesis/tox-envfile
hypothesis/pip-sync-faster
...
```

You can just use that `gh api` command to dynamically generate the value for commando's `--repos` argument:

```console
$ commando --repos $(gh api -X GET search/repositories --paginate -f 'q=cookiecutter.json in:readme org:hypothesis archived:false' -q '.items | .[] | .full_name' | xargs) \
           --command 'make template'
           --branch cookiecutter
           --commit-message 'Apply updates from cookiecutter'
           --pr-title 'Apply updates from cookiecutter'
```

Commando can currently be run locally. I'll also send a follow-up PR to add a workflow for running it on GitHub Actions.

You could use this to do all sorts of things besides applying updates from the cookiecutter. Any project change that you can automate with a script, Commando can then run that script for you in whatever list of repos you want and send PRs.

I think it's particularly interesting the `cookiecutter.json` is a JSON file so you can easily write Python scripts to parse this file, make a change to the data, write the file back to disk, then run `make template`. For example you could upgrade all the project's development Python versions to their latest patch versions. Or you could add Python 3.11 to the Python versions (none of our projects have 3.11 in their `cookiecutter.json`'s yet). So a Commando command could send PRs to all projects to update their Python patch versions or to add Python 3.11, and then we'd see whether CI passes on those PRs.

## A note on optimization

Commando is pretty slow because every time you run it it clones each GitHub repo anew. This also means that if the command is something like `make template` tox has to create all the venvs anew each time as well.

An obvious optimisation would be to add a command line option for the directory that repos should be cloned to and for it to clone the repos to that directory (each repo in a subdir) or just update the existing cloned repo (`git fetch --prune`) if one already exists. It would also need to check that the repo is clean (no uncommitted changes or local commits).

This can probably be implemented without things getting too complicated but I'd like to leave it for later (if ever) because it's significantly more complicated than the unoptimized solution and honestly it probably doesn't matter much that Commando is a bit slow.

## Testing

Install Commando from this branch:

```terminal
pipx install git+https://github.com/hypothesis/commando.git@initial-implementation
```

I should probably add these to the README but you'll also need Git and GitHub CLI (installed and appropriately configured) and gh-pr-upsert:

```terminal
pipx install git+https://github.com/hypothesis/gh-pr-upsert.git@initial-implementation
```

Now let's send a test PR to the three test repos. Feel free to actually do this:

```console
$ commando --repos hypothesis/cookiecutter-pyapp-test hypothesis/cookiecutter-pypackage-test hypothesis/cookiecutter-pyramid-app-test \
            --command 'echo testing >> README.md' \
            --branch testing \
            --commit-message "This is a test commit" \
            --pr-title "This is a test PR"
hypothesis/cookiecutter-pyapp-test> cloning
hypothesis/cookiecutter-pyapp-test> echo testing >> README.md
hypothesis/cookiecutter-pyapp-test> committing changes
hypothesis/cookiecutter-pyapp-test> sending PR
hypothesis/cookiecutter-pyapp-test> https://github.com/hypothesis/cookiecutter-pyapp-test/pull/14
hypothesis/cookiecutter-pypackage-test> cloning
hypothesis/cookiecutter-pypackage-test> echo testing >> README.md
hypothesis/cookiecutter-pypackage-test> committing changes
hypothesis/cookiecutter-pypackage-test> sending PR
hypothesis/cookiecutter-pypackage-test> https://github.com/hypothesis/cookiecutter-pypackage-test/pull/38
hypothesis/cookiecutter-pyramid-app-test> cloning
hypothesis/cookiecutter-pyramid-app-test> echo testing >> README.md
hypothesis/cookiecutter-pyramid-app-test> committing changes
hypothesis/cookiecutter-pyramid-app-test> sending PR
hypothesis/cookiecutter-pyramid-app-test> https://github.com/hypothesis/cookiecutter-pyramid-app-test/pull/47
```

Thanks to gh-pr-upsert if you run the same command again it will just print out the same three existing PRs, it won't create duplicate PRs.

If the command doesn't produce any changes then no PR will be sent. An easy way to test this is by using `make template` as the command since the three test repos are currently up to date with the cookiecutter:

```console
$ commando --repos hypothesis/cookiecutter-pyapp-test hypothesis/cookiecutter-pypackage-test hypothesis/cookiecutter-pyramid-app-test \
           --command 'make template' \
           --branch cookiecutter \
           --commit-message "Apply updates from cookiecutter" \
           --pr-title "Apply updates from cookiecutter"
hypothesis/cookiecutter-pyapp-test> cloning
hypothesis/cookiecutter-pyapp-test> make template
hypothesis/cookiecutter-pyapp-test> no changes to commit
hypothesis/cookiecutter-pypackage-test> cloning
hypothesis/cookiecutter-pypackage-test> make template
hypothesis/cookiecutter-pypackage-test> no changes to commit
hypothesis/cookiecutter-pyramid-app-test> cloning
hypothesis/cookiecutter-pyramid-app-test> make template
hypothesis/cookiecutter-pyramid-app-test> no changes to commit
```