### PR TITLE
Insert `"pypi": "yes"` into `cookiecutter.json`

### DIFF
--- a/.cookiecutter/cookiecutter.json
+++ b/.cookiecutter/cookiecutter.json
@@ -15,7 +15,7 @@
     "console_script": "yes",
     "devdata": "no",
     "services": "no",
-    "pypi": "no",
+    "pypi": "yes",
     "dependabot_pip_interval": "monthly",
     "__entry_point": "commando",
     "__github_url": "https://github.com/hypothesis/commando",


### PR DESCRIPTION
This is needed to prevent the cookiecutter from removing the PyPI support from this project now that PyPI is optional. See: https://github.com/hypothesis/cookiecutters/pull/104
